### PR TITLE
Update ingredientrules.json

### DIFF
--- a/ingredientrules.json
+++ b/ingredientrules.json
@@ -1261,6 +1261,7 @@
         "Ethylhexyl Methoxycinnamate",
         "Ethylhexyl Palmitate",
         "Ethylhexylglycerin",
+        "Ethylhexylglycerine",
         "Glutamic Acid",
         "Glycereth-2 Cocoate",
         "Glyceryl Caprylate",


### PR DESCRIPTION
added alternative spelling ETHYLHEXYLGLYCERINE because it was on the product i was checking in the ingredients list at https://mixedchicks.net/products/hair-products/condition-detangle/leave-in-conditioner-10oz/

## What does this change?

added alternative spelling ETHYLHEXYLGLYCERINE for ETHYLHEXYLGLYCERIN

## Why?

glycerine is an alternative spelling variant of glycerin.
https://www.bachelorprint.com/british-english-vs-american-english/glycerine-or-glycerin/
https://en.wikipedia.org/wiki/Glycerol

## Checklist

- [yes] I've considered label spelling variations — "Sodium Laurel Sulfate" and "Sodium Lauryl Sulfate" are genuinely different spellings that both appear on real product labels, so both may need separate entries
- [yes] I've checked for duplicate entries (same ingredient already listed in this or another category)
- [yes] This is based on a source I can link to (included above)

---

> **Note for reviewers:** Matching is case-insensitive — "Sodium Lauryl Sulfate" and "sodium lauryl sulfate" are treated as identical by the tool. If you see case-only duplicates in this PR or in the existing database, they can and should be removed.
